### PR TITLE
added getFrameDelay method to read the animation delay of a given frame

### DIFF
--- a/js/giflib.library.js
+++ b/js/giflib.library.js
@@ -192,5 +192,18 @@ GifLibFile.prototype = {
     cData.data.set(new Uint8ClampedArray(arr));
     //Module._free(rawImgData);
     frame.putImageData(cData, img.imageDesc.left, img.imageDesc.top);
+  },
+
+  getFrameDelay: function(gif, imageIdx) {
+    var img = this.getFrameStruct(gif, imageIdx);
+    var extensionBlock = this.makeStruct(this.ExtensionBlockStruct, img.extensionBlockPtr);
+
+    //The delay is stored in the second and third extension data bytes.
+    var extensionBytes = Module.getValue(extensionBlock.bytesPtr, '*');
+    var low = (extensionBytes & 0x0000ff00) >> 8;
+    var high = (extensionBytes & 0x00ff0000) >> 8;
+
+    //Times 10 because it's stored as hundreds of a second and JS usually uses thousands (ms).
+    return (high | low) * 10;
   }
 };

--- a/js/giflib.library.js
+++ b/js/giflib.library.js
@@ -199,7 +199,7 @@ GifLibFile.prototype = {
     var extensionBlock = this.makeStruct(this.ExtensionBlockStruct, img.extensionBlockPtr);
 
     //The delay is stored in the second and third extension data bytes.
-    var extensionBytes = Module.getValue(extensionBlock.bytesPtr, '*');
+    var extensionBytes = Module.getValue(extensionBlock.bytesPtr, 'i32');
     var low = (extensionBytes & 0x0000ff00) >> 8;
     var high = (extensionBytes & 0x00ff0000) >> 8;
 


### PR DESCRIPTION
Tested this with different gifs with short and long delays and also unevenly distributed delays.

It's the first emscripten code I've written so maybe there's an easier way to read and combine the second and third byte into an unsigned short. I couldn't find any api documentation for `getValue` etc.

Also this code was inspired by https://gist.github.com/keefo/78a083c148b9da2d2a40
